### PR TITLE
Fix for battery level while charging

### DIFF
--- a/custom_components/pawfit/sensor.py
+++ b/custom_components/pawfit/sensor.py
@@ -40,6 +40,11 @@ class PawfitSensor(SensorEntity):
         loc = self._coordinator.data.get(str(self._tracker_id), {})
         value = loc.get(self._kind)
         
+        # Special handling for battery level
+        if self._kind == "battery" and value is not None:
+            # If battery is negative, it means charging - return absolute value
+            return abs(int(value))
+        
         # Add debug logging specifically for activity sensors
         if self._kind in ["steps_today", "calories_today", "active_time_today"]:
             _LOGGER.debug(f"Activity sensor {self._attr_name} ({self._kind}): tracker_data_keys={list(loc.keys())}, value={value}")


### PR DESCRIPTION
The PawFit API returns a negative number for the battery level when the device is on charge (e.g. "-60" means "The device is charging and the battery level is currently 60%). The negative number is being correctly identified by PawfitChargingSensor but we want to ensure that the battery level is always an absolute number.
Identified in #8 

This fix is un-tested until my trackers discharge enough for me to test it.